### PR TITLE
Update cargo and build to rust 1.54

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -83,6 +83,8 @@ jobs:
           rustup default
           cargo -V
           rustc -V
+      - name: Check format
+        run: cargo fmt -- --check
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arrayref"
@@ -74,9 +74,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "blake2b_simd"
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -973,15 +973,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1914,9 +1914,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2027,12 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ homepage = "https://docspell.org"
 license = "GPLv3"
 repository = "https://github.com/docspell/dsc"
 build = "build.rs"
+keywords = [ "docspell", "cli" ]
+categories = [ "command-line-utilities" ]
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ id or the integration endpoint instead of being authenticated.
 Install [nix](https://nixos.org/download.html#nix-quick-install) and
 run `nix-shell` in the source root. This installs required rust tools.
 Alternatively, the rust tool chain can be setup with
-[rustup](https://rustup.rs/).
+[rustup](https://rustup.rs/). Currently, dsc requires rust >= 1.54.0.
 
 Building the binary for your platform (The second line strips the
 binary of debug symbols):

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
       };
     in cleanSrc ../.;
 
-  cargoSha256 = "07q26wf3ix8sn4ajq8zfl4wvfr58055fdai12mzi8yj48lyyks3j";
+  cargoSha256 = "0zs2g07lg3vqgy9mci6m87hg0jkvyc4vmsij76rnqj95p1nhkghb";
 
   # only unit tests can be run
   checkPhase = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,13 @@
 let
   pkgs_source = import (builtins.fetchTarball "channel:nixos-21.05");
-  # moz_overlay = import (builtins.fetchTarball
-  #   https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
-  #  pkgs = pkgs_source { overlays = [ moz_overlay ]; };
+  #pkgs = pkgs_source {};
+  moz_overlay = import (builtins.fetchTarball
+    https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = pkgs_source { overlays = [ moz_overlay ]; };
   # arm = pkgs_source {
   #   crossSystem = pkgs.lib.systems.examples.raspberryPi;
   # };
-  pkgs = pkgs_source {};
+
 in
 pkgs.mkShell {
   # nativeBuildInputs = with pkgs; [ rustc cargo gcc pkg-config ];
@@ -20,11 +21,7 @@ pkgs.mkShell {
     [ rustfmt
       clippy
       cargo
-      rustc
-      # (pkgs.rustChannelOfTargets "stable" null
-      #                     [ "x86_64-unknown-linux-gnu"
-      #                       "arm-unknown-linux-gnueabihf" ])
-      # arm.stdenv.cc
+      pkgs.latest.rustChannels.stable.rust
     ];
   PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
 #  RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";


### PR DESCRIPTION
Due to the clap library, rust 1.54 is now required. This is not yet in
nixpkgs, so the mozilla overlay is used now.

Adds a format check to ci.