### PR TITLE
Export: Implement configurable link-naming scheme (implements #29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "predicates",
  "prettytable-rs",
  "reqwest",
+ "sanitize-filename",
  "serde",
  "serde-lexpr",
  "serde_json",
@@ -1629,6 +1630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf18934a12018228c5b55a6dae9df5d0641e3566b3630cb46cc55564068e7c2f"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ snafu = { version = "0.6" }
 toml = { version = "0.5" }
 zip = { version = "0.5" }
 pathdiff = "0.2"
+sanitize-filename = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 file-locker = { version = "1.0" }

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -48,9 +48,7 @@ pub fn collective_from_subdir(
     Ok(None)
 }
 
-pub fn safe_filename(name: &str) -> String {
-    name.replace("/", "-")
-}
+pub use sanitize_filename::sanitize as safe_filename;
 
 pub fn safe_filepath(name: &str, path_delimiter: &Option<String>) -> String {
     let path_segments: Vec<String> = match path_delimiter {


### PR DESCRIPTION
Symlinks created as part of the export function can now be configured
to be either named after an items' id, or after its name, using `--link-name=id` or `--link-name=name`.

For that, I needed a complete `safe_filename()` implementation, so I replaced that with the one from the `sanitize-filename` crate.