### PR TITLE
Try guessing the collective in the upload command

### DIFF
--- a/src/cli/cmd/file_exists.rs
+++ b/src/cli/cmd/file_exists.rs
@@ -66,7 +66,9 @@ pub fn check_file(
     opts: &EndpointOpts,
     ctx: &Context,
 ) -> Result<CheckFileResult, Error> {
-    let fa = opts.to_file_auth(ctx);
+    let fa = opts
+        .to_file_auth(ctx, &|| None)
+        .ok_or(Error::NoCollective)?;
     let hash = digest::digest_file_sha256(file).context(DigestFailSnafu { path: file })?;
     let mut result = ctx.client.file_exists(hash, &fa).context(HttpClientSnafu)?;
     result.file = file.canonicalize().ok().map(|p| p.display().to_string());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,9 @@
 mod common;
+
 use crate::common::{mk_cmd, Result};
 use assert_cmd::prelude::*;
 use dsc::http::payload::{BasicResult, ItemDetail, SearchResult, SourceAndTags, Summary};
+use std::fs;
 use std::{io::Write, path::Path, process::Command};
 
 const ITEM_ID1: &str = "2wKtSUVt3Kj-mAmexmm1jFe-BU6aY6PN4vo-5cpaDD2EyRm";
@@ -94,6 +96,34 @@ fn remote_upload_int_endpoint() -> Result<()> {
     assert
         .success()
         .stdout(basic_result_json(true, "Files submitted."));
+    Ok(())
+}
+
+#[test]
+fn remote_upload_int_endpoint_guess_collective() -> Result<()> {
+    let base = std::path::Path::new("target/test_remote_upload");
+    if base.exists() {
+        fs::remove_dir_all(base)?;
+    }
+
+    let demo = base.join("demo");
+    std::fs::create_dir_all(demo.clone())?;
+    std::fs::copy("README.md", demo.join("README.md"))?;
+
+    let mut cmd = mk_cmd()?;
+    let assert = cmd
+        .arg("upload")
+        .args(&[
+            "-i",
+            "--header",
+            "Docspell-Integration:test123",
+            "--traverse",
+        ])
+        .arg("target/test_remote_upload")
+        .assert();
+    assert
+        .success()
+        .stdout(basic_result_json(true, "Uploaded 1"));
     Ok(())
 }
 


### PR DESCRIPTION
If directories are traversed with the `upload` command and `-i` is
specfified to use the integration endpoint, the collective is now
deduced from the file being uploaded. This is the same as done in the
`watch` command (and also applies now to `cleanup` and `file-exists`).
If single files are uploaded, a collective must be given with the
arguments.

Fixes: #125