### PR TITLE
nix: add development VM configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "docspell-flake": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "dir": "nix",
+        "lastModified": 1677220620,
+        "narHash": "sha256-zIQDu4zZNnMMmKqB/9jwz03GdstIzHgvLX1aV6a6UXU=",
+        "owner": "eikek",
+        "repo": "docspell",
+        "rev": "c88f8c21d45e078c6e30ad5de3c200f14026988a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "nix",
+        "owner": "eikek",
+        "repo": "docspell",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -19,7 +39,7 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1671096816,
@@ -38,15 +58,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677080879,
-        "narHash": "sha256-0SjW4/d3Rkw6C7hHZ5lxT4r6Pw9vzQb6Il6zYWwe2Bo=",
+        "lastModified": 1673704454,
+        "narHash": "sha256-5Wdj1MgdOgn3+dMFIBtg+IAYZApjF8JzwLWDPieg0C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5dad40450d272a1ea2413f4a67ac08760649e89",
+        "rev": "a83ed85c14fcf242653df6f4b0974b7e1c73c6c6",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-22.11",
         "type": "indirect"
       }
     },
@@ -70,6 +91,20 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1677080879,
+        "narHash": "sha256-0SjW4/d3Rkw6C7hHZ5lxT4r6Pw9vzQb6Il6zYWwe2Bo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5dad40450d272a1ea2413f4a67ac08760649e89",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1677063315,
         "narHash": "sha256-qiB4ajTeAOVnVSAwCNEEkoybrAlA+cpeiBxLobHndE8=",
         "owner": "NixOS",
@@ -86,9 +121,10 @@
     },
     "root": {
       "inputs": {
+        "docspell-flake": "docspell-flake",
         "flake-parts": "flake-parts",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       }
     }
   },

--- a/nix/nixosConfigurations/default.nix
+++ b/nix/nixosConfigurations/default.nix
@@ -1,0 +1,124 @@
+{ modulesPath, pkgs, lib, config, ... }:
+let
+  full-text-search = {
+    enabled = true;
+    solr.url = "http://localhost:${toString config.services.solr.port}/solr/docspell";
+    postgresql = {
+      pg-config = {
+        "german" = "my-germam";
+      };
+    };
+  };
+in
+{
+  # Common development config
+  imports = [ (modulesPath + "/virtualisation/qemu-vm.nix") ];
+  services.openssh = {
+    enable = true;
+    settings.PermitRootLogin = "yes";
+  };
+  i18n = {
+    defaultLocale = "en_US.UTF-8";
+  };
+  console.keyMap = "us";
+
+  services.xserver = {
+    enable = false;
+  };
+
+  networking = {
+    hostName = "docspelltest";
+    firewall.allowedTCPPorts = [ 7880 ];
+  };
+  users.users.root.password = "root";
+
+  # Otherwise oomkiller kills docspell
+  virtualisation.memorySize = 4096;
+
+  virtualisation.forwardPorts = [
+    # SSH
+    { from = "host"; host.port = 64022; guest.port = 22; }
+    # Docspell
+    { from = "host"; host.port = 64080; guest.port = 7880; }
+  ];
+  system.stateVersion = "22.11";
+  # This slows down the build of a vm
+  documentation.enable = false;
+
+  # Add dsc to the environment
+  environment.systemPackages = [ pkgs.dsc ];
+  # Docspell service configuration and its requirements
+  services.docspell-joex = {
+    enable = true;
+    waitForTarget = "solr-init.target";
+    bind.address = "0.0.0.0";
+    base-url = "http://localhost:7878";
+    jvmArgs = [ "-J-Xmx1536M" ];
+    inherit full-text-search;
+  };
+  services.docspell-restserver = {
+    enable = true;
+    bind.address = "0.0.0.0";
+    openid = lib.mkForce [ ];
+    backend = {
+      addons.enabled = true;
+      signup = {
+        mode = "open";
+      };
+    };
+    integration-endpoint = {
+      enabled = true;
+      http-header = {
+        enabled = true;
+        header-value = "test123";
+      };
+    };
+    inherit full-text-search;
+    extraConfig = {
+      files = {
+        default-store = "database";
+        stores = {
+          minio = {
+            enabled = true;
+          };
+        };
+      };
+    };
+  };
+  nixpkgs.config = {
+    permittedInsecurePackages = [
+      "solr-8.6.3"
+    ];
+  };
+
+  services.solr = {
+    enable = true;
+  };
+  # This is needed to run solr script as user solr
+  users.users.solr.useDefaultShell = true;
+
+  systemd.services.solr-init =
+    let
+      solrPort = toString config.services.solr.port;
+      initSolr = ''
+        if [ ! -f ${config.services.solr.stateDir}/docspell_core ]; then
+          while ! echo "" | ${pkgs.inetutils}/bin/telnet localhost ${solrPort}
+          do
+             echo "Waiting for SOLR become ready..."
+             sleep 1.5
+          done
+          ${pkgs.su}/bin/su -s ${pkgs.bash}/bin/sh solr -c "${pkgs.solr}/bin/solr create_core -c docspell -p ${solrPort}";
+          touch ${config.services.solr.stateDir}/docspell_core
+        fi
+      '';
+    in
+    {
+      script = initSolr;
+      after = [ "solr.target" ];
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "solr.target" ];
+      description = "Create a core at solr";
+    };
+
+
+}


### PR DESCRIPTION
I have added a repurposed nixosConfiguration from docspell proper to this repo and added the ability to install dsc from overlays.

The VM is runnable:

```
export NIXPKGS_ALLOW_INSECURE=1; nix run '.#nixosConfigurations.dev-vm.config.system.build.vm' --impure
```

NIXPKGS_ALLOW_INSECURE is needed for solr