### PR TITLE
Have naersk's nixpkgs follow dsc's

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     naersk.url = "github:nix-community/naersk/master";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
     docspell-flake = { url = "github:eikek/docspell?dir=nix"; };
   };
 


### PR DESCRIPTION
I noticed including dsc adds another nixpkgs to my flake.lock which is included by naersk. Adding the follows-line should have them depend on the same nixpkgs-version